### PR TITLE
use the python 3.9 image because gcloud is broken on python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       
   deploy:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/python:3.9
     steps:
       - setup_remote_docker:
           version: 20.10.11


### PR DESCRIPTION
Signed-off-by: Nick Santos <nick.santos@docker.com>
