### PR TITLE
flip to go 1.18.6 image, which should have python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.18.6
     steps:
       - checkout
       - run: go get -v ./...
@@ -36,7 +36,7 @@ jobs:
       
   deploy:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/go:1.18.6
     steps:
       - setup_remote_docker:
           version: 20.10.11

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tilt-dev/cloud.tilt.dev
 
-go 1.19
+go 1.18
 
 require github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
Signed-off-by: Nick Santos <nick.santos@docker.com>
